### PR TITLE
Fixes PermissionDenied errors

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -289,9 +289,7 @@ func (e *Exporter) collectDishContext(ch chan<- prometheus.Metric) bool {
 	resp, err := e.Client.Handle(ctx, req)
 	if err != nil {
 		st, ok := status.FromError(err)
-		if ok && st.Code() == 7 {
-			log.Info("Got PermissionDenied for Endpoint ... continuing")
-		} else {
+		if ok && st.Code() != 7 {
 			log.Errorf("failed to collect context from dish: %s", err.Error())
 			return false
 		}


### PR DESCRIPTION
A quick and dirty fix for the scraper not working anymore with latest firmware releases.

## Description
This should fix all further PermissionDenied errors and still abort on any other error.  It will cause some no longer accessible metrics to be missing, but still manages to scrape most of the data.

At least it fixed mine so far:
<img width="1373" alt="Screenshot 2021-06-25 at 11 18 04" src="https://user-images.githubusercontent.com/6527744/123401413-0d0ad300-d5a7-11eb-977f-8917fa899ed6.png">


## Related Issue
Relates to https://github.com/danopstech/starlink_exporter/issues/32

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [x] All commits are GPG signed
