### PR TITLE
Fix Dish's uptime & DeviceInfo

### DIFF
--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -320,16 +320,6 @@ func (e *Exporter) collectDishContext(ch chan<- prometheus.Metric) bool {
 	}
 
 	dishC := resp.GetDishGetContext()
-	dishI := dishC.GetDeviceInfo()
-
-	ch <- prometheus.MustNewConstMetric(
-		dishInfo, prometheus.GaugeValue, 1.00,
-		dishI.GetId(),
-		dishI.GetHardwareVersion(),
-		dishI.GetSoftwareVersion(),
-		dishI.GetCountryCode(),
-		fmt.Sprint(dishI.GetUtcOffsetS()),
-	)
 
 	ch <- prometheus.MustNewConstMetric(
 		dishCellId, prometheus.GaugeValue, float64(dishC.GetCellId()),
@@ -372,7 +362,17 @@ func (e *Exporter) collectDishStatus(ch chan<- prometheus.Metric) bool {
 	}
 
 	dishStatus := resp.GetDishGetStatus()
+	dishI := dishStatus.GetDeviceInfo()
 	dishS := dishStatus.GetDeviceState()
+
+	ch <- prometheus.MustNewConstMetric(
+		dishInfo, prometheus.GaugeValue, 1.00,
+		dishI.GetId(),
+		dishI.GetHardwareVersion(),
+		dishI.GetSoftwareVersion(),
+		dishI.GetCountryCode(),
+		fmt.Sprint(dishI.GetUtcOffsetS()),
+	)
 
 	ch <- prometheus.MustNewConstMetric(
 		dishUptimeSeconds, prometheus.GaugeValue, float64(dishS.GetUptimeS()),

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -321,7 +321,6 @@ func (e *Exporter) collectDishContext(ch chan<- prometheus.Metric) bool {
 
 	dishC := resp.GetDishGetContext()
 	dishI := dishC.GetDeviceInfo()
-	dishS := dishC.GetDeviceState()
 
 	ch <- prometheus.MustNewConstMetric(
 		dishInfo, prometheus.GaugeValue, 1.00,
@@ -330,10 +329,6 @@ func (e *Exporter) collectDishContext(ch chan<- prometheus.Metric) bool {
 		dishI.GetSoftwareVersion(),
 		dishI.GetCountryCode(),
 		fmt.Sprint(dishI.GetUtcOffsetS()),
-	)
-
-	ch <- prometheus.MustNewConstMetric(
-		dishUptimeSeconds, prometheus.GaugeValue, float64(dishS.GetUptimeS()),
 	)
 
 	ch <- prometheus.MustNewConstMetric(
@@ -377,6 +372,11 @@ func (e *Exporter) collectDishStatus(ch chan<- prometheus.Metric) bool {
 	}
 
 	dishStatus := resp.GetDishGetStatus()
+	dishS := dishStatus.GetDeviceState()
+
+	ch <- prometheus.MustNewConstMetric(
+		dishUptimeSeconds, prometheus.GaugeValue, float64(dishS.GetUptimeS()),
+	)
 
 	ch <- prometheus.MustNewConstMetric(
 		dishState, prometheus.GaugeValue, float64(dishStatus.GetState().Number()),


### PR DESCRIPTION
The DeviceState with the dish's uptime and the DeviceInfo is available in the GetDishGetStatus.
Let's use this since the GetDishGetContext is locked (for now?)

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
I guess originally the DeviceState and DeviceInfo parts where in the DishGetContext
but they are now only available in the DishGetStatus, So I updated the call's location.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
